### PR TITLE
Should monitor itself allowing to easily control log levels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <spring-boot-admin.version>2.2.3</spring-boot-admin.version>
         <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
-        <docker-image.version>${spring-boot-admin.version}</docker-image.version>
+        <docker-image.version>${spring-boot-admin.version}-1</docker-image.version>
     </properties>
 
     <dependencyManagement>
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>de.codecentric</groupId>
@@ -44,7 +43,15 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
-            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.codecentric</groupId>
+            <artifactId>spring-boot-admin-starter-client</artifactId>
+            <version>2.2.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,18 @@
 server:
   port: 8080
+
+spring:
+  boot.admin.client:
+    url: http://localhost:8080
+    instance:
+      name: Spring Boot Admin
+      service-base-url: http://localhost:8080
+      management-base-url: http://localhost:8081
+
+management:
+  server:
+    port: 8081
+  endpoints.web.exposure.include: "*"
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
SBA (Spring Boot Admin) should use Actuator so it could "manage itself"
enabling usage of SBA features including viewing SBA's log, controlling
log levels etc.