### PR TITLE
Enable actuator's k8s probes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
     <properties>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
-        <spring-boot-admin.version>2.2.3</spring-boot-admin.version>
-        <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
-        <docker-image.version>${spring-boot-admin.version}-1</docker-image.version>
+        <spring-boot-admin.version>2.3.0</spring-boot-admin.version>
+        <spring-boot.version>2.3.1.RELEASE</spring-boot.version>
+        <docker-image.version>${spring-boot-admin.version}</docker-image.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,5 @@ management:
   endpoint:
     health:
       show-details: always
+  health:
+    probes.enabled: true # Enable k8s liveness and readiness probes, see https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-kubernetes-probes


### PR DESCRIPTION
Upgrade spring and spring-boot-admin in order to enable liveness and readiness k8s probes. See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html\#production-ready-kubernetes-probes